### PR TITLE
feat : 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 
 	// DB 설정 후 Build
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/team/neorangloa/NeorangloaApplication.java
+++ b/src/main/java/com/team/neorangloa/NeorangloaApplication.java
@@ -2,9 +2,10 @@ package com.team.neorangloa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 @EnableJpaAuditing
 public class NeorangloaApplication {
 

--- a/src/main/java/com/team/neorangloa/domain/user/controller/UserController.java
+++ b/src/main/java/com/team/neorangloa/domain/user/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.team.neorangloa.domain.user.controller;
+
+
+import com.team.neorangloa.domain.user.dto.SignupRequestDto;
+import com.team.neorangloa.domain.user.service.UserService;
+import com.team.neorangloa.global.result.ResultCode;
+import com.team.neorangloa.global.result.ResultResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<ResultResponse> signup(
+            @RequestBody SignupRequestDto signupRequestDto){
+        userService.signup(signupRequestDto);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_SIGNUP_SUCCESS));
+    }
+}

--- a/src/main/java/com/team/neorangloa/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/team/neorangloa/domain/user/dto/SignupRequestDto.java
@@ -1,0 +1,12 @@
+package com.team.neorangloa.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SignupRequestDto {
+    private String email;
+
+    private String password;
+
+    private String nickname;
+}

--- a/src/main/java/com/team/neorangloa/domain/user/entity/User.java
+++ b/src/main/java/com/team/neorangloa/domain/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.team.neorangloa.domain.user.entity;
 
 import com.team.neorangloa.global.entity.BaseTimeEntity;
+import com.team.neorangloa.global.util.PasswordEncryptionUtil;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,8 +22,23 @@ public class User extends BaseTimeEntity{
     private String email;
 
     @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
     private String nickname;
 
     @Column(name = "IS_REMOVED" ,nullable = false)
     private boolean removed;
+
+    @Builder
+    public User(String email, String password, String nickname, boolean removed){
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.removed = removed;
+    }
+
+    public void encryptPassword(){
+        this.password = PasswordEncryptionUtil.encrypt(password);
+    }
 }

--- a/src/main/java/com/team/neorangloa/domain/user/exception/DuplicatedEmailException.java
+++ b/src/main/java/com/team/neorangloa/domain/user/exception/DuplicatedEmailException.java
@@ -1,0 +1,10 @@
+package com.team.neorangloa.domain.user.exception;
+
+import com.team.neorangloa.global.error.ErrorCode;
+import com.team.neorangloa.global.error.exception.BusinessException;
+
+public class DuplicatedEmailException extends BusinessException {
+    public DuplicatedEmailException(){
+        super(ErrorCode.USER_EMAIL_DUPLICATED);
+    }
+}

--- a/src/main/java/com/team/neorangloa/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/team/neorangloa/domain/user/mapper/UserMapper.java
@@ -1,0 +1,19 @@
+package com.team.neorangloa.domain.user.mapper;
+
+
+import com.team.neorangloa.domain.user.dto.SignupRequestDto;
+import com.team.neorangloa.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    public User toEntity(SignupRequestDto dto){
+        return User.builder()
+                .email(dto.getEmail())
+                .password(dto.getPassword())
+                .nickname(dto.getNickname())
+                .removed(false)
+                .build();
+    }
+}

--- a/src/main/java/com/team/neorangloa/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/team/neorangloa/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.team.neorangloa.domain.user.repository;
+
+import com.team.neorangloa.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/team/neorangloa/domain/user/service/UserService.java
+++ b/src/main/java/com/team/neorangloa/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.team.neorangloa.domain.user.dto.SignupRequestDto;
 import com.team.neorangloa.domain.user.entity.User;
 import com.team.neorangloa.domain.user.mapper.UserMapper;
 import com.team.neorangloa.domain.user.repository.UserRepository;
+import com.team.neorangloa.domain.user.exception.DuplicatedEmailException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,10 +15,18 @@ public class UserService {
     private final UserMapper userMapper;
 
     public void signup(SignupRequestDto signupRequestDto) {
+        validateDuplication(signupRequestDto);
 
         User user = userMapper.toEntity(signupRequestDto);
         user.encryptPassword();
         userRepository.save(user);
     }
-
+    private void validateDuplication(SignupRequestDto signupRequestDto) {
+        validateEmail(signupRequestDto.getEmail());
+    }
+    private void validateEmail(String email) {
+        if (userRepository.findByEmail(email).isPresent()) {
+            throw new DuplicatedEmailException();
+        }
+    }
 }

--- a/src/main/java/com/team/neorangloa/domain/user/service/UserService.java
+++ b/src/main/java/com/team/neorangloa/domain/user/service/UserService.java
@@ -1,0 +1,23 @@
+package com.team.neorangloa.domain.user.service;
+
+import com.team.neorangloa.domain.user.dto.SignupRequestDto;
+import com.team.neorangloa.domain.user.entity.User;
+import com.team.neorangloa.domain.user.mapper.UserMapper;
+import com.team.neorangloa.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    public void signup(SignupRequestDto signupRequestDto) {
+
+        User user = userMapper.toEntity(signupRequestDto);
+        user.encryptPassword();
+        userRepository.save(user);
+    }
+
+}

--- a/src/main/java/com/team/neorangloa/global/error/ErrorCode.java
+++ b/src/main/java/com/team/neorangloa/global/error/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(400, "U001", "잘못된 비밀번호"),
     USER_NOT_FOUND_ERROR(400, "U002", "사용자를 찾을 수 없음"),
     UNAUTHORIZED_ACCESS_ERROR(403, "U003", "승인되지 않은 접근"),
-    USER_USERNAME_DUPLICATED(409, "U004", "회원 아이디 중복"),
+    USER_EMAIL_DUPLICATED(409, "U004", "회원 이메일 중복"),
 
     // Post
     POST_DUPLICATION_ERROR(409, "S001", "게시물의 이름이 중복됨"),

--- a/src/main/java/com/team/neorangloa/global/error/ErrorResponse.java
+++ b/src/main/java/com/team/neorangloa/global/error/ErrorResponse.java
@@ -1,0 +1,61 @@
+package com.team.neorangloa.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class ErrorResponse {
+    private String businessCode;
+    private String errorMessage;
+    private List<FieldError> errors;
+
+    private ErrorResponse(ErrorCode code, List<FieldError> fieldErrors) {
+        this.businessCode = code.getCode();
+        this.errorMessage = code.getMessage();
+        this.errors = fieldErrors;
+    }
+
+    private ErrorResponse(ErrorCode code) {
+        this.businessCode = code.getCode();
+        this.errorMessage = code.getMessage();
+        this.errors = new ArrayList<>();
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+    @Getter
+    @AllArgsConstructor
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors =
+                    bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(
+                            error ->
+                                    new FieldError(
+                                            error.getField(),
+                                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/com/team/neorangloa/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/team/neorangloa/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.team.neorangloa.global.error;
+
+import com.team.neorangloa.global.error.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.team.neorangloa.global.error.ErrorCode.INPUT_INVALID_VALUE;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error(e.getMessage(), e);
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleRuntimeException(BusinessException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response =
+                ErrorResponse.builder()
+                        .errorMessage(errorCode.getMessage())
+                        .businessCode(errorCode.getCode())
+                        .build();
+        log.warn(e.getMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
+        final ErrorResponse response = ErrorResponse.of(INPUT_INVALID_VALUE, e.getBindingResult());
+        log.warn(e.getMessage());
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/team/neorangloa/global/error/exception/BusinessException.java
+++ b/src/main/java/com/team/neorangloa/global/error/exception/BusinessException.java
@@ -1,7 +1,9 @@
 package com.team.neorangloa.global.error.exception;
 
 import com.team.neorangloa.global.error.ErrorCode;
+import lombok.Getter;
 
+@Getter
 public class BusinessException extends RuntimeException{
     private final ErrorCode errorCode;
 

--- a/src/main/java/com/team/neorangloa/global/result/ResultCode.java
+++ b/src/main/java/com/team/neorangloa/global/result/ResultCode.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResultCode {
     // user
-    USER_REGISTRATION_SUCCESS("U001", "사용자 등록 성공"),
+    USER_SIGNUP_SUCCESS("U001", "사용자 등록 성공"),
     USER_USERNAME_DUPLICATED("U002", "회원 아이디 중복"),
     USER_USERNAME_NOT_DUPLICATED("U003", "회원 아이디 중복되지 않음"),
     USER_LOGIN_SUCCESS("U004", "회원 로그인 성공"),

--- a/src/main/java/com/team/neorangloa/global/util/PasswordEncryptionUtil.java
+++ b/src/main/java/com/team/neorangloa/global/util/PasswordEncryptionUtil.java
@@ -1,0 +1,13 @@
+package com.team.neorangloa.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+
+public class PasswordEncryptionUtil {
+
+    public static String encrypt(String password) {
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        return passwordEncoder.encode(password);
+    }
+}


### PR DESCRIPTION
## 추가한 기능 설명
회원가입 기능
 - 패스워드 인코딩해서 저장
회원가입 시 이메일이 중복된 값이면 예외처리
 - 에러 핸들링 추가   
<br>

## check list
1. 회원가입 api 테스트 시 사용자 등록 성공 메시지, 유저를 조회해봤을때 password값이 인코딩 됐는지
2. 중복된 이메일로 api 요청을 했을때, 회원 이메일 중복 메시지 응답나타나는지 확인

- [o] issue number를 브랜치 앞에 추가 하였는가?
- [o] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
