### PR TITLE
feat: 게시물, 댓글 수정 및 삭제 시 글쓴이 여부 체크

### DIFF
--- a/src/main/java/com/team/neorangloa/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/team/neorangloa/domain/comment/controller/CommentController.java
@@ -43,18 +43,20 @@ public class CommentController {
     @PutMapping("/{commentId}")
     @LoginRequired
     public ResponseEntity<ResultResponse> updateComment(@PathVariable Long commentId,
-                                                        @RequestBody @Valid CommentUpdateRequest request) {
+                                                        @RequestBody @Valid CommentUpdateRequest request,
+                                                        @LoginUser User loginUser) {
         Comment comment = commentService.findCommentById(commentId);
-        commentService.updateComment(comment, request);
+        commentService.updateComment(loginUser, comment, request);
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_UPDATE_SUCCESS));
     }
 
     @DeleteMapping("/{commentId}")
     @LoginRequired
-    public ResponseEntity<ResultResponse> deleteComment(@PathVariable Long commentId) {
+    public ResponseEntity<ResultResponse> deleteComment(@PathVariable Long commentId,
+                                                        @LoginUser User loginUser){
         Comment comment = commentService.findCommentById(commentId);
-        commentService.deleteComment(comment);
+        commentService.deleteComment(loginUser, comment);
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_DELETE_SUCCESS));
     }

--- a/src/main/java/com/team/neorangloa/domain/comment/controller/CommentRaidController.java
+++ b/src/main/java/com/team/neorangloa/domain/comment/controller/CommentRaidController.java
@@ -43,18 +43,20 @@ public class CommentRaidController {
     @PutMapping("/{commentRaidId}")
     @LoginRequired
     public ResponseEntity<ResultResponse> updateCommentRaid(@PathVariable Long commentRaidId,
-                                                            @RequestBody @Valid CommentRaidUpdateRequest request) {
+                                                            @RequestBody @Valid CommentRaidUpdateRequest request,
+                                                            @LoginUser User loginUser) {
         CommentRaid commentRaid = commentRaidService.findCommentRaidById(commentRaidId);
-        commentRaidService.updateCommentRaid(commentRaid, request);
+        commentRaidService.updateCommentRaid(loginUser, commentRaid, request);
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_UPDATE_SUCCESS));
     }
 
     @DeleteMapping("/{commentRaidId}")
     @LoginRequired
-    public ResponseEntity<ResultResponse> deleteCommentRaid(@PathVariable Long commentRaidId) {
+    public ResponseEntity<ResultResponse> deleteCommentRaid(@PathVariable Long commentRaidId,
+                                                            @LoginUser User loginUser) {
         CommentRaid commentRaid = commentRaidService.findCommentRaidById(commentRaidId);
-        commentRaidService.deleteCommentRaid(commentRaid);
+        commentRaidService.deleteCommentRaid(loginUser, commentRaid);
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.COMMENT_DELETE_SUCCESS));
     }

--- a/src/main/java/com/team/neorangloa/domain/comment/exception/CommentAuthorMismatchException.java
+++ b/src/main/java/com/team/neorangloa/domain/comment/exception/CommentAuthorMismatchException.java
@@ -1,0 +1,10 @@
+package com.team.neorangloa.domain.comment.exception;
+
+import com.team.neorangloa.global.error.ErrorCode;
+import com.team.neorangloa.global.error.exception.BusinessException;
+
+public class CommentAuthorMismatchException extends BusinessException {
+    public CommentAuthorMismatchException() {
+        super(ErrorCode.COMMENT_MISMATCH_AUTHOR_ERROR);
+    }
+}

--- a/src/main/java/com/team/neorangloa/domain/comment/service/CommentRaidService.java
+++ b/src/main/java/com/team/neorangloa/domain/comment/service/CommentRaidService.java
@@ -4,6 +4,7 @@ import com.team.neorangloa.domain.comment.dto.CommentRaidRequest;
 import com.team.neorangloa.domain.comment.dto.CommentRaidResponse;
 import com.team.neorangloa.domain.comment.dto.CommentRaidUpdateRequest;
 import com.team.neorangloa.domain.comment.entity.CommentRaid;
+import com.team.neorangloa.domain.post.entity.PostRaid;
 import com.team.neorangloa.domain.user.entity.User;
 
 import java.util.List;
@@ -13,7 +14,8 @@ public interface CommentRaidService {
 
     public CommentRaid findCommentRaidById(Long commentRaidId);
 
-    public void updateCommentRaid(CommentRaid commentRaid, CommentRaidUpdateRequest request);
-    public void deleteCommentRaid(CommentRaid commentRaid);
+    public void updateCommentRaid(User user, CommentRaid commentRaid, CommentRaidUpdateRequest request);
+    public void deleteCommentRaid(User user, CommentRaid commentRaid);
     public List<CommentRaidResponse> findCommentRaidByPostRaidId(Integer page, Integer size, Long postRaidId);
+    public void checkIsAuthor(User user, CommentRaid commentRaid);
 }

--- a/src/main/java/com/team/neorangloa/domain/comment/service/CommentService.java
+++ b/src/main/java/com/team/neorangloa/domain/comment/service/CommentService.java
@@ -13,7 +13,8 @@ public interface CommentService {
 
     public Comment findCommentById(Long commentId);
 
-    public void updateComment(Comment comment, CommentUpdateRequest request);
-    public void deleteComment(Comment comment);
+    public void updateComment(User user, Comment comment, CommentUpdateRequest request);
+    public void deleteComment(User user, Comment comment);
     public List<CommentResponse> findCommentByPostId(Integer page, Integer size, Long postId);
+    public void checkIsAuthor(User user, Comment comment);
 }

--- a/src/main/java/com/team/neorangloa/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/team/neorangloa/domain/comment/service/CommentServiceImpl.java
@@ -5,6 +5,7 @@ import com.team.neorangloa.domain.comment.dto.CommentRequest;
 import com.team.neorangloa.domain.comment.dto.CommentResponse;
 import com.team.neorangloa.domain.comment.dto.CommentUpdateRequest;
 import com.team.neorangloa.domain.comment.entity.Comment;
+import com.team.neorangloa.domain.comment.exception.CommentAuthorMismatchException;
 import com.team.neorangloa.domain.comment.repository.CommentRepository;
 import com.team.neorangloa.domain.post.entity.Post;
 import com.team.neorangloa.domain.post.service.PostService;
@@ -42,13 +43,15 @@ public class CommentServiceImpl implements CommentService{
 
     @Transactional
     @Override
-    public void updateComment(Comment comment, CommentUpdateRequest request) {
+    public void updateComment(User loginUser, Comment comment, CommentUpdateRequest request) {
+        checkIsAuthor(loginUser, comment);
         comment.updateComment(request);
     }
 
     @Transactional
     @Override
-    public void deleteComment(Comment comment) {
+    public void deleteComment(User loginUser, Comment comment) {
+        checkIsAuthor(loginUser, comment);
         comment.setRemoved(true);
         commentRepository.save(comment);
     }
@@ -59,5 +62,13 @@ public class CommentServiceImpl implements CommentService{
         PageRequest pageRequest = PageRequest.of(page,size);
         List<Comment> comments = commentRepository.findCommentByPostId(pageRequest, postId);
         return commentMapper.toDtoList(comments);
+    }
+
+    @Transactional
+    @Override
+    public void checkIsAuthor(User loginUser, Comment comment){
+        if (!loginUser.getId().equals(comment.getAuthor().getId())) {
+            throw new CommentAuthorMismatchException();
+        }
     }
 }

--- a/src/main/java/com/team/neorangloa/domain/post/controller/PostController.java
+++ b/src/main/java/com/team/neorangloa/domain/post/controller/PostController.java
@@ -62,16 +62,17 @@ public class PostController {
                                                      @RequestBody @Valid PostRequest postRequest,
                                                      @LoginUser User loginUser) {
         Post post = postService.findPostById(postId);
-        postService.updatePost(post, postRequest);
+        postService.updatePost(loginUser,post, postRequest);
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POST_UPDATE_SUCCESS));
     }
 
     @DeleteMapping("/{postId}")
     @LoginRequired
-    public ResponseEntity<ResultResponse> deletePost(@PathVariable Long postId) {
+    public ResponseEntity<ResultResponse> deletePost(@PathVariable Long postId,
+                                                     @LoginUser User loginUser) {
         Post post = postService.findPostById(postId);
-        postService.deletePost(post);
+        postService.deletePost(loginUser,post);
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POST_DELETE_SUCCESS));
     }

--- a/src/main/java/com/team/neorangloa/domain/post/controller/PostRaidController.java
+++ b/src/main/java/com/team/neorangloa/domain/post/controller/PostRaidController.java
@@ -54,18 +54,20 @@ public class PostRaidController {
     @PutMapping("/{postRaidId}")
     @LoginRequired
     public ResponseEntity<ResultResponse> updateRaidPost(@PathVariable Long postRaidId,
-                                                         @RequestBody @Valid PostRaidRequest postRaidRequest) {
+                                                         @RequestBody @Valid PostRaidRequest postRaidRequest,
+                                                         @LoginUser User loginUser) {
         PostRaid postRaid = postRaidService.findPostRaidById(postRaidId);
-        postRaidService.updatePost(postRaid, postRaidRequest);
+        postRaidService.updatePost(loginUser, postRaid, postRaidRequest);
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POST_UPDATE_SUCCESS));
     }
 
     @DeleteMapping("/{postRaidId}")
     @LoginRequired
-    public ResponseEntity<ResultResponse> deleteRaidPost(@PathVariable Long postRaidId) {
+    public ResponseEntity<ResultResponse> deleteRaidPost(@PathVariable Long postRaidId,
+                                                         @LoginUser User loginUser) {
         PostRaid postRaid = postRaidService.findPostRaidById(postRaidId);
-        postRaidService.deletePost(postRaid);
+        postRaidService.deletePost(loginUser, postRaid);
 
         return ResponseEntity.ok(ResultResponse.of(ResultCode.POST_DELETE_SUCCESS));
     }

--- a/src/main/java/com/team/neorangloa/domain/post/entity/PostRaid.java
+++ b/src/main/java/com/team/neorangloa/domain/post/entity/PostRaid.java
@@ -60,7 +60,7 @@ public class PostRaid extends BaseTimeEntity {
 
     @Builder
     public PostRaid(String title, String content, int viewCounts, boolean removed, int maxAttacker, int maxSupporter,
-                    LocalDateTime finishedAt, User user, Raid raid) {
+                    LocalDateTime finishedAt, User author, Raid raid) {
         this.title= title;
         this.content = content;
         this.viewCounts = viewCounts;

--- a/src/main/java/com/team/neorangloa/domain/post/exception/PostAuthorMismatchException.java
+++ b/src/main/java/com/team/neorangloa/domain/post/exception/PostAuthorMismatchException.java
@@ -1,0 +1,10 @@
+package com.team.neorangloa.domain.post.exception;
+
+import com.team.neorangloa.global.error.ErrorCode;
+import com.team.neorangloa.global.error.exception.BusinessException;
+
+public class PostAuthorMismatchException extends BusinessException {
+    public PostAuthorMismatchException() {
+        super(ErrorCode.POST_MISMATCH_AUTHOR_EROOR);
+    }
+}

--- a/src/main/java/com/team/neorangloa/domain/post/service/PostRaidService.java
+++ b/src/main/java/com/team/neorangloa/domain/post/service/PostRaidService.java
@@ -4,6 +4,7 @@ import com.team.neorangloa.domain.post.dto.PostListResponse;
 import com.team.neorangloa.domain.post.dto.PostRaidListResponse;
 import com.team.neorangloa.domain.post.dto.PostRaidRequest;
 import com.team.neorangloa.domain.post.dto.PostRequest;
+import com.team.neorangloa.domain.post.entity.Post;
 import com.team.neorangloa.domain.post.entity.PostRaid;
 import com.team.neorangloa.domain.raid.entity.Raid;
 import com.team.neorangloa.domain.user.entity.User;
@@ -23,7 +24,9 @@ public interface PostRaidService {
 
     public List<PostRaidListResponse> getPosts(int page, int size);
 
-    public void updatePost(PostRaid postRaid, PostRaidRequest postRaidRequest);
+    public void updatePost(User user, PostRaid postRaid, PostRaidRequest postRaidRequest);
 
-    public void deletePost(PostRaid postRaid);
+    public void deletePost(User user, PostRaid postRaid);
+
+    public void checkIsAuthor(User user, PostRaid postRaid);
 }

--- a/src/main/java/com/team/neorangloa/domain/post/service/PostRaidServiceImpl.java
+++ b/src/main/java/com/team/neorangloa/domain/post/service/PostRaidServiceImpl.java
@@ -4,6 +4,7 @@ import com.team.neorangloa.domain.post.PostRaidMapper;
 import com.team.neorangloa.domain.post.dto.PostRaidListResponse;
 import com.team.neorangloa.domain.post.dto.PostRaidRequest;
 import com.team.neorangloa.domain.post.entity.PostRaid;
+import com.team.neorangloa.domain.post.exception.PostAuthorMismatchException;
 import com.team.neorangloa.domain.post.repository.PostRaidRepository;
 import com.team.neorangloa.domain.raid.entity.Raid;
 import com.team.neorangloa.domain.raid.repository.RaidRepository;
@@ -91,7 +92,8 @@ public class PostRaidServiceImpl implements PostRaidService{
 
     @Transactional
     @Override
-    public void updatePost(PostRaid postRaid, PostRaidRequest postRaidRequest) {
+    public void updatePost(User loginUser, PostRaid postRaid, PostRaidRequest postRaidRequest) {
+        checkIsAuthor(loginUser, postRaid);
         postRaid.updatePost(postRaidRequest);
         Raid raid = raidRepository.findRaidByName(postRaidRequest.getRaidName()).orElseThrow(
                 () -> new BusinessException(ErrorCode.RAID_NOT_FOUND_ERROR));
@@ -101,8 +103,17 @@ public class PostRaidServiceImpl implements PostRaidService{
 
     @Transactional
     @Override
-    public void deletePost(PostRaid postRaid) {
+    public void deletePost(User loginUser, PostRaid postRaid) {
+        checkIsAuthor(loginUser, postRaid);
         postRaid.setRemoved(true);
         postRaidRepository.save(postRaid);
+    }
+
+    @Transactional
+    @Override
+    public void checkIsAuthor(User loginUser, PostRaid postRaid){
+        if (!loginUser.getId().equals(postRaid.getAuthor().getId())) {
+            throw new PostAuthorMismatchException();
+        }
     }
 }

--- a/src/main/java/com/team/neorangloa/domain/post/service/PostService.java
+++ b/src/main/java/com/team/neorangloa/domain/post/service/PostService.java
@@ -20,7 +20,9 @@ public interface PostService {
 
     public List<PostListResponse> getPosts(int page, int size);
 
-    public void updatePost(Post post,PostRequest postRequest);
+    public void updatePost(User user, Post post,PostRequest postRequest);
 
-    public void deletePost(Post post);
+    public void deletePost(User user, Post post);
+
+    public void checkIsAuthor(User user, Post post);
 }

--- a/src/main/java/com/team/neorangloa/global/error/ErrorCode.java
+++ b/src/main/java/com/team/neorangloa/global/error/ErrorCode.java
@@ -21,9 +21,11 @@ public enum ErrorCode {
     POST_DUPLICATION_ERROR(409, "S001", "게시물의 이름이 중복됨"),
     POST_NOT_FOUND_ERROR(400, "S002", "게시물을 찾을 수 없음"),
     RAID_NOT_FOUND_ERROR(409, "S003", "레이드 정보를 찾을 수 없음"),
+    POST_MISMATCH_AUTHOR_EROOR(409,"S004","게시물 글쓴이와 일치하지 않음"),
 
     // Comment
-    COMMENT_NOT_FOUND_ERROR(400, "C001", "댓글을 찾을 수 없음");
+    COMMENT_NOT_FOUND_ERROR(400, "C001", "댓글을 찾을 수 없음"),
+    COMMENT_MISMATCH_AUTHOR_ERROR(409,"C002","댓글 글쓴이와 일치하지 않음");
 
     private final int status;
     private final String code;


### PR DESCRIPTION
## 추가한 기능 설명
게시물 및 댓글 수정, 삭제 시에 
로그인된 유저가 해당 글쓴이와 일치하는지 체크하는 로직 추가
<br>

## check list
1. 게시물, 댓글을 생성한 유저가 수정 및 삭제가 가능한지
2. 다른 유저가 해당 게시물, 댓글을 수정 및 삭제 요청 시에 정상적으로 에러가 발생하는지

- [O] issue number를 브랜치 앞에 추가 하였는가?
- [O] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
